### PR TITLE
add solana-client-utils; prioritization fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,6 +3364,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanctum-solana-compute-budget-utils"
+version = "0.1.0"
+dependencies = [
+ "solana-sdk",
+]
+
+[[package]]
 name = "sanctum-solana-test-utils"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3356,6 +3356,7 @@ dependencies = [
 name = "sanctum-solana-client-utils"
 version = "0.1.0"
 dependencies = [
+ "log",
  "medians",
  "solana-client",
  "solana-rpc-client-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2017,6 +2017,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indxvec"
+version = "1.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f939f8f54f1855df393e7f758f7f2086ad3b90f41d654b2d6d7dfddc3808e9"
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2232,15 @@ checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "medians"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f735d68e5e69089b2ee21897396ae1143daed0c20dc5c58b4e79cd504fe2c05"
+dependencies = [
+ "indxvec",
 ]
 
 [[package]]
@@ -3338,6 +3353,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanctum-solana-client-utils"
+version = "0.1.0"
+dependencies = [
+ "medians",
+ "solana-client",
+ "solana-rpc-client-api",
+ "solana-sdk",
+]
+
+[[package]]
 name = "sanctum-solana-test-utils"
 version = "0.1.0"
 dependencies = [
@@ -3367,7 +3392,7 @@ dependencies = [
  "solana-sdk",
  "solana-version",
  "spl-token",
- "spl-token-2022 0.9.0",
+ "spl-token-2022",
  "tempfile",
  "tokio",
 ]
@@ -3416,7 +3441,7 @@ dependencies = [
  "sanctum-solana-test-utils",
  "solana-program",
  "solana-readonly-account",
- "spl-token-2022 0.9.0",
+ "spl-token-2022",
  "spl_token_interface",
 ]
 
@@ -3777,7 +3802,7 @@ dependencies = [
  "solana-config-program",
  "solana-sdk",
  "spl-token",
- "spl-token-2022 1.0.0",
+ "spl-token-2022",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
  "thiserror",
@@ -4475,7 +4500,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-status",
  "solana-version",
- "spl-token-2022 1.0.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -4779,7 +4804,7 @@ dependencies = [
  "spl-associated-token-account",
  "spl-memo",
  "spl-token",
- "spl-token-2022 1.0.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -4951,7 +4976,7 @@ dependencies = [
  "num-traits",
  "solana-program",
  "spl-token",
- "spl-token-2022 1.0.0",
+ "spl-token-2022",
  "thiserror",
 ]
 
@@ -5039,20 +5064,6 @@ dependencies = [
 
 [[package]]
 name = "spl-tlv-account-resolution"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062e148d3eab7b165582757453632ffeef490c02c86a48bfdb4988f63eefb3b9"
-dependencies = [
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-tlv-account-resolution"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "615d381f48ddd2bb3c57c7f7fb207591a2a05054639b18a62e785117dd7a8683"
@@ -5082,28 +5093,6 @@ dependencies = [
 
 [[package]]
 name = "spl-token-2022"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4abf34a65ba420584a0c35f3903f8d727d1f13ababbdc3f714c6b065a686e86"
-dependencies = [
- "arrayref",
- "bytemuck",
- "num-derive 0.4.1",
- "num-traits",
- "num_enum 0.7.1",
- "solana-program",
- "solana-zk-token-sdk",
- "spl-memo",
- "spl-pod",
- "spl-token",
- "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.3.0",
- "spl-type-length-value",
- "thiserror",
-]
-
-[[package]]
-name = "spl-token-2022"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d697fac19fd74ff472dfcc13f0b442dd71403178ce1de7b5d16f83a33561c059"
@@ -5121,7 +5110,7 @@ dependencies = [
  "spl-token",
  "spl-token-group-interface",
  "spl-token-metadata-interface",
- "spl-transfer-hook-interface 0.4.1",
+ "spl-transfer-hook-interface",
  "spl-type-length-value",
  "thiserror",
 ]
@@ -5155,22 +5144,6 @@ dependencies = [
 
 [[package]]
 name = "spl-transfer-hook-interface"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051d31803f873cabe71aec3c1b849f35248beae5d19a347d93a5c9cccc5d5a9b"
-dependencies = [
- "arrayref",
- "bytemuck",
- "solana-program",
- "spl-discriminator",
- "spl-pod",
- "spl-program-error",
- "spl-tlv-account-resolution 0.4.0",
- "spl-type-length-value",
-]
-
-[[package]]
-name = "spl-transfer-hook-interface"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aabdb7c471566f6ddcee724beb8618449ea24b399e58d464d6b5bc7db550259"
@@ -5181,7 +5154,7 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-program-error",
- "spl-tlv-account-resolution 0.5.1",
+ "spl-tlv-account-resolution",
  "spl-type-length-value",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "sanctum-solana-cli-utils",
     "sanctum-solana-test-utils",
     "sanctum-solana-client-utils",
+    "sanctum-solana-compute-budget-utils",
     "sanctum-stored-account",
     "sanctum-token-ratio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "sanctum-misc-utils",
     "sanctum-solana-cli-utils",
     "sanctum-solana-test-utils",
+    "sanctum-solana-client-utils",
     "sanctum-stored-account",
     "sanctum-token-ratio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ http-body-util = "^0.1"
 hyper = "^1" # not compatible with reqwest version pulled in by solana
 hyper-util = "^0.1"
 log = "^0.4"
+medians = "3.0"
 num-derive = ">=0.1"
 num-traits = ">=0.1"
 proptest = "^1"

--- a/sanctum-solana-client-utils/Cargo.toml
+++ b/sanctum-solana-client-utils/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = { workspace = true }
 medians = "3.0"
 solana-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }

--- a/sanctum-solana-client-utils/Cargo.toml
+++ b/sanctum-solana-client-utils/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sanctum-solana-client-utils"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+medians = "3.0"
+solana-client = { workspace = true }
+solana-rpc-client-api = { workspace = true }
+solana-sdk = { workspace = true }

--- a/sanctum-solana-client-utils/Cargo.toml
+++ b/sanctum-solana-client-utils/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [dependencies]
 log = { workspace = true }
-medians = "3.0"
+medians = { workspace = true }
 solana-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-sdk = { workspace = true }

--- a/sanctum-solana-client-utils/src/lib.rs
+++ b/sanctum-solana-client-utils/src/lib.rs
@@ -1,0 +1,3 @@
+mod prioritization_fee;
+
+pub use prioritization_fee::*;

--- a/sanctum-solana-client-utils/src/prioritization_fee.rs
+++ b/sanctum-solana-client-utils/src/prioritization_fee.rs
@@ -1,0 +1,100 @@
+use medians::Medianf64;
+
+use solana_client::nonblocking::rpc_client::RpcClient as NonblockingRpcClient;
+use solana_client::rpc_client::RpcClient;
+use solana_client::rpc_response::RpcPrioritizationFee;
+use solana_rpc_client_api::client_error::Error as ClientError;
+use solana_sdk::compute_budget::ComputeBudgetInstruction;
+use solana_sdk::instruction::Instruction;
+use solana_sdk::pubkey::Pubkey;
+
+const MAX_SLOT_DISPLACEMENT: u64 = 150;
+const WEIGHTED_MEDIAN_EPSILON: f64 = 0.0001;
+
+fn get_compute_budget_ixs(unit_limit: u32, unit_price_micro_lamports: u64) -> [Instruction; 2] {
+    [
+        ComputeBudgetInstruction::set_compute_unit_limit(unit_limit),
+        ComputeBudgetInstruction::set_compute_unit_price(unit_price_micro_lamports),
+    ]
+}
+
+// Assume ~150 slots of sample size
+fn get_slot_weighted_median_prioritization_fees(rpc_prio_fees: &[RpcPrioritizationFee]) -> u64 {
+    if rpc_prio_fees.is_empty() {
+        return 0u64;
+    }
+
+    // min_slot (the most recent slot) is assumed to be max - MAX_SLOT_DISPLACEMENT
+    // NOTE: data for the slot at max - MAX_SLOT_DISPLACEMENT might be missing but we
+    // assume that it exists and the fee was 0 for that slot
+    let min_slot = rpc_prio_fees
+        .iter()
+        .max_by_key(|fee| fee.slot)
+        .unwrap()
+        .slot
+        - MAX_SLOT_DISPLACEMENT;
+
+    let (v, w): (Vec<f64>, Vec<f64>) = rpc_prio_fees
+        .iter()
+        .filter_map(|fee| {
+            if fee.prioritization_fee == 0 {
+                None
+            } else {
+                Some((
+                    fee.prioritization_fee as f64,
+                    (1 + fee.slot - min_slot) as f64 / MAX_SLOT_DISPLACEMENT as f64,
+                ))
+            }
+        })
+        .into_iter()
+        .unzip();
+
+    // Unwrap safty: the length of v and w are always the same
+    let median = v.medf_weighted(&w, WEIGHTED_MEDIAN_EPSILON).unwrap();
+    median.floor() as u64
+}
+
+fn get_compute_budget_ixs_with_rpc_prio_fees(
+    rpc_prio_fees: &[RpcPrioritizationFee],
+    unit_limit: u32,
+) -> Result<[Instruction; 2], ClientError> {
+    let unit_price_micro_lamports = get_slot_weighted_median_prioritization_fees(&rpc_prio_fees);
+    Ok(get_compute_budget_ixs(
+        unit_limit,
+        unit_price_micro_lamports,
+    ))
+}
+
+pub fn get_slot_weighted_mean_compute_budget_ixs(
+    client: RpcClient,
+    addresses: &[Pubkey],
+    unit_limit: u32,
+) -> Result<[Instruction; 2], ClientError> {
+    let rpc_prio_fees = client.get_recent_prioritization_fees(addresses)?;
+    get_compute_budget_ixs_with_rpc_prio_fees(&rpc_prio_fees, unit_limit)
+}
+
+pub async fn get_slot_weighted_mean_compute_budget_ixs_nonblocking(
+    client: NonblockingRpcClient,
+    addresses: &[Pubkey],
+    unit_limit: u32,
+) -> Result<[Instruction; 2], ClientError> {
+    let rpc_prio_fees = client.get_recent_prioritization_fees(addresses).await?;
+    get_compute_budget_ixs_with_rpc_prio_fees(&rpc_prio_fees, unit_limit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let rpc = RpcClient::new_with_commitment(
+            "https://api.mainnet-beta.solana.com".to_owned(),
+            solana_sdk::commitment_config::CommitmentConfig::processed(),
+        );
+
+        let res = get_slot_weighted_mean_compute_budget_ixs(rpc, &[], 1000).unwrap();
+        println!("priority ixs: {:?}", res);
+    }
+}

--- a/sanctum-solana-client-utils/src/prioritization_fee.rs
+++ b/sanctum-solana-client-utils/src/prioritization_fee.rs
@@ -29,6 +29,7 @@ pub fn calc_slot_weighted_median_prioritization_fees(
     rpc_prio_fees: &[RpcPrioritizationFee],
 ) -> u64 {
     if rpc_prio_fees.is_empty() {
+        log::warn!("Given sample for the recent prioritization fee was empty");
         return 0u64;
     }
 
@@ -60,6 +61,7 @@ pub fn calc_slot_weighted_median_prioritization_fees(
     let median = values
         .medf_weighted(&weights, WEIGHTED_MEDIAN_EPSILON)
         .unwrap();
+    log::debug!("Calculated slot weighted median for prioritization fee: {median}");
     median.floor() as u64
 }
 

--- a/sanctum-solana-client-utils/src/prioritization_fee.rs
+++ b/sanctum-solana-client-utils/src/prioritization_fee.rs
@@ -7,7 +7,6 @@ use solana_client::{
 };
 use solana_rpc_client_api::{
     client_error::Error as ClientError, config::RpcSimulateTransactionConfig,
-    response::RpcSimulateTransactionResult,
 };
 use solana_sdk::{
     compute_budget::ComputeBudgetInstruction, instruction::Instruction, message::Message,
@@ -65,29 +64,29 @@ pub fn calc_slot_weighted_median_prioritization_fees(
     median.floor() as u64
 }
 
-// /// Runs simulation and returns consumed compute unit
-// pub fn estimate_compute_unit_limit(
-//     client: RpcClient,
-//     ixs: &[Instruction],
-// ) -> Result<u64, ClientError> {
-//     let tx = Transaction::new_unsigned(Message::new(ixs, None));
-//     client
-//         .simulate_transaction_with_config(
-//             &tx,
-//             RpcSimulateTransactionConfig {
-//                 sig_verify: false,
-//                 ..Default::default()
-//             },
-//         )?
-//         .value
-//         .units_consumed
-//         .ok_or(ClientError::new_with_request(
-//             solana_rpc_client_api::client_error::ErrorKind::Custom(
-//                 "Could not retrieve consumed compute units from simulation".to_owned(),
-//             ),
-//             solana_rpc_client_api::request::RpcRequest::SimulateTransaction,
-//         ))
-// }
+/// Runs simulation and returns consumed compute unit
+pub fn estimate_compute_unit_limit(
+    client: RpcClient,
+    ixs: &[Instruction],
+) -> Result<u64, ClientError> {
+    let tx = Transaction::new_unsigned(Message::new(ixs, None));
+    client
+        .simulate_transaction_with_config(
+            &tx,
+            RpcSimulateTransactionConfig {
+                sig_verify: false,
+                ..Default::default()
+            },
+        )?
+        .value
+        .units_consumed
+        .ok_or(ClientError::new_with_request(
+            solana_rpc_client_api::client_error::ErrorKind::Custom(
+                "Could not retrieve consumed compute units from simulation".to_owned(),
+            ),
+            solana_rpc_client_api::request::RpcRequest::SimulateTransaction,
+        ))
+}
 
 /// Calculates slot weighted median prioritiziation fee and generate compute
 /// budget ixs

--- a/sanctum-solana-client-utils/src/prioritization_fee.rs
+++ b/sanctum-solana-client-utils/src/prioritization_fee.rs
@@ -64,6 +64,7 @@ pub fn calc_slot_weighted_median_prioritization_fees(
     median.floor() as u64
 }
 
+/// TODO: WIP
 /// Runs simulation and returns consumed compute unit
 pub fn estimate_compute_unit_limit(
     client: RpcClient,

--- a/sanctum-solana-client-utils/src/prioritization_fee.rs
+++ b/sanctum-solana-client-utils/src/prioritization_fee.rs
@@ -19,7 +19,7 @@ fn get_compute_budget_ixs(unit_limit: u32, unit_price_micro_lamports: u64) -> [I
 }
 
 // Assume ~150 slots of sample size
-fn get_slot_weighted_median_prioritization_fees(rpc_prio_fees: &[RpcPrioritizationFee]) -> u64 {
+fn calc_slot_weighted_median_prioritization_fees(rpc_prio_fees: &[RpcPrioritizationFee]) -> u64 {
     if rpc_prio_fees.is_empty() {
         return 0u64;
     }
@@ -46,7 +46,6 @@ fn get_slot_weighted_median_prioritization_fees(rpc_prio_fees: &[RpcPrioritizati
                 ))
             }
         })
-        .into_iter()
         .unzip();
 
     // Unwrap safty: the length of v and w are always the same
@@ -58,7 +57,7 @@ fn get_compute_budget_ixs_with_rpc_prio_fees(
     rpc_prio_fees: &[RpcPrioritizationFee],
     unit_limit: u32,
 ) -> Result<[Instruction; 2], ClientError> {
-    let unit_price_micro_lamports = get_slot_weighted_median_prioritization_fees(&rpc_prio_fees);
+    let unit_price_micro_lamports = calc_slot_weighted_median_prioritization_fees(rpc_prio_fees);
     Ok(get_compute_budget_ixs(
         unit_limit,
         unit_price_micro_lamports,

--- a/sanctum-solana-client-utils/src/prioritization_fee.rs
+++ b/sanctum-solana-client-utils/src/prioritization_fee.rs
@@ -1,18 +1,18 @@
 use std::cmp::min;
 
 use medians::Medianf64;
-
-use solana_client::nonblocking::rpc_client::RpcClient as NonblockingRpcClient;
-use solana_client::rpc_client::RpcClient;
-use solana_client::rpc_response::RpcPrioritizationFee;
-use solana_rpc_client_api::client_error::Error as ClientError;
-use solana_rpc_client_api::config::RpcSimulateTransactionConfig;
-use solana_rpc_client_api::response::RpcSimulateTransactionResult;
-use solana_sdk::compute_budget::ComputeBudgetInstruction;
-use solana_sdk::instruction::Instruction;
-use solana_sdk::message::Message;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transaction::Transaction;
+use solana_client::{
+    nonblocking::rpc_client::RpcClient as NonblockingRpcClient, rpc_client::RpcClient,
+    rpc_response::RpcPrioritizationFee,
+};
+use solana_rpc_client_api::{
+    client_error::Error as ClientError, config::RpcSimulateTransactionConfig,
+    response::RpcSimulateTransactionResult,
+};
+use solana_sdk::{
+    compute_budget::ComputeBudgetInstruction, instruction::Instruction, message::Message,
+    pubkey::Pubkey, transaction::Transaction,
+};
 
 const MAX_SLOT_DISPLACEMENT: u64 = 150;
 const WEIGHTED_MEDIAN_EPSILON: f64 = 0.0001;

--- a/sanctum-solana-client-utils/src/prioritization_fee.rs
+++ b/sanctum-solana-client-utils/src/prioritization_fee.rs
@@ -44,7 +44,12 @@ pub fn get_writable_account_keys(ixs: &[Instruction]) -> Vec<Pubkey> {
     res
 }
 
-// NOTE: assumes unreported slots has `prioritization_fee = 0`
+/// Calculate slot weighted median value of given sample of prioritization fees
+/// (see get_recent_prioritization_fees rpc call)
+///
+/// Weights are assigned such that the values would range from 1/(# of slots) to 1
+///
+/// NOTE: assumes unreported slots has `prioritization_fee = 0`
 pub fn calc_slot_weighted_median_prioritization_fees(
     rpc_prio_fees: &[RpcPrioritizationFee],
 ) -> Option<u64> {
@@ -74,7 +79,7 @@ pub fn calc_slot_weighted_median_prioritization_fees(
     Some(median.floor() as u64)
 }
 
-/// Runs simulation and returns consumed compute unit
+/// Runs a simulation and returns esimated compute units
 pub fn estimate_compute_unit_limit(
     client: RpcClient,
     tx: &impl SerializableTransaction,
@@ -99,8 +104,6 @@ pub fn estimate_compute_unit_limit(
 
 /// Calculates slot weighted median prioritiziation fee and generate compute
 /// budget ixs
-///
-/// NOTE: assumes <= `MAX_SLOT_DISPLACEMENT` slots of sample size for `rpc_prio_fees`
 pub fn get_compute_budget_ixs_with_rpc_prio_fees(
     rpc_prio_fees: &[RpcPrioritizationFee],
     unit_limit: u32,

--- a/sanctum-solana-client-utils/src/prioritization_fee.rs
+++ b/sanctum-solana-client-utils/src/prioritization_fee.rs
@@ -64,7 +64,7 @@ fn get_compute_budget_ixs_with_rpc_prio_fees(
     ))
 }
 
-pub fn get_slot_weighted_mean_compute_budget_ixs(
+pub fn get_slot_weighted_median_compute_budget_ixs(
     client: RpcClient,
     addresses: &[Pubkey],
     unit_limit: u32,
@@ -73,7 +73,7 @@ pub fn get_slot_weighted_mean_compute_budget_ixs(
     get_compute_budget_ixs_with_rpc_prio_fees(&rpc_prio_fees, unit_limit)
 }
 
-pub async fn get_slot_weighted_mean_compute_budget_ixs_nonblocking(
+pub async fn get_slot_weighted_median_compute_budget_ixs_nonblocking(
     client: NonblockingRpcClient,
     addresses: &[Pubkey],
     unit_limit: u32,
@@ -93,7 +93,7 @@ mod tests {
             solana_sdk::commitment_config::CommitmentConfig::processed(),
         );
 
-        let res = get_slot_weighted_mean_compute_budget_ixs(rpc, &[], 1000).unwrap();
+        let res = get_slot_weighted_median_compute_budget_ixs(rpc, &[], 1000).unwrap();
         println!("priority ixs: {:?}", res);
     }
 }

--- a/sanctum-solana-compute-budget-utils/Cargo.toml
+++ b/sanctum-solana-compute-budget-utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sanctum-solana-compute-budget-utils"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+solana-sdk = { workspace = true }

--- a/sanctum-solana-compute-budget-utils/src/lib.rs
+++ b/sanctum-solana-compute-budget-utils/src/lib.rs
@@ -1,0 +1,65 @@
+use solana_sdk::{
+    address_lookup_table_account::AddressLookupTableAccount,
+    compute_budget::ComputeBudgetInstruction,
+    hash::Hash,
+    instruction::Instruction,
+    message::{v0::Message, VersionedMessage},
+    pubkey::Pubkey,
+    signer::SignerError,
+    signers::Signers,
+    transaction::VersionedTransaction,
+};
+
+#[derive(Debug)]
+pub struct ComputeBudgetParams {
+    pub unit_limit: u32,
+    pub unit_price_micro_lamports: u64,
+}
+
+pub fn create_versioned_transaction_with_compute_budget<T: Signers + ?Sized>(
+    payer: &Pubkey,
+    ixs: &[Instruction],
+    address_lookup_table_accounts: &[AddressLookupTableAccount],
+    recent_blockhash: Hash,
+    signers: &T,
+    ComputeBudgetParams {
+        unit_limit,
+        unit_price_micro_lamports,
+    }: ComputeBudgetParams,
+) -> Result<VersionedTransaction, SignerError> {
+    let cb_ixs = vec![
+        ComputeBudgetInstruction::set_compute_unit_limit(unit_limit),
+        ComputeBudgetInstruction::set_compute_unit_price(unit_price_micro_lamports),
+    ];
+    let ixs = [cb_ixs, ixs.to_vec()].concat();
+
+    VersionedTransaction::try_new(
+        VersionedMessage::V0(
+            Message::try_compile(payer, &ixs, address_lookup_table_accounts, recent_blockhash)
+                .unwrap(),
+        ),
+        signers,
+    )
+}
+
+pub fn get_writable_account_keys(ixs: &[Instruction]) -> Vec<Pubkey> {
+    let mut res = ixs
+        .iter()
+        .map(|ix| {
+            ix.accounts
+                .iter()
+                .filter_map(|acc_meta| {
+                    if acc_meta.is_writable {
+                        Some(acc_meta.pubkey)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
+        .concat();
+    res.sort();
+    res.dedup();
+    res
+}


### PR DESCRIPTION
closes #44 

 - Since `Transaction` stores `CompiledInstruction`, decided to have a helper function that just returns compute budget ixs, rather than making it accept tx and modifying it.
 - Instead of time weighted median, decided to do compute the "slot displacement" weighted median value of prioritization fees